### PR TITLE
exanic-capture support for up-to 8 interfaces simultaniously

### DIFF
--- a/util/exanic-capture.c
+++ b/util/exanic-capture.c
@@ -498,6 +498,12 @@ int main(int argc, char *argv[])
         switch (c)
         {
             case 'i':
+                if (rx_ctxs_no >= EXA_MAX_IFACES)
+                {
+                    fprintf(stderr, "maximum interfaces supported: %d\n", EXA_MAX_IFACES);
+                    return 1;
+                }
+
                 if (exanic_find_port_by_interface_name(
                     optarg, rx_ctxs[rx_ctxs_no].device, 16, &rx_ctxs[rx_ctxs_no].port_number) != 0
                     &&
@@ -743,7 +749,7 @@ err_open_savefile:
     return 1;
 
 usage_error:
-    fprintf(stderr, "Usage: %s -i interface\n", argv[0]);
+    fprintf(stderr, "Usage: %s -i interface...\n", argv[0]);
     fprintf(stderr, "           [-w savefile] [-s snaplen] [-C file_size]\n");
     fprintf(stderr, "           [-F file_format] [-p] [-H] [-N] [filter...]\n");
     fprintf(stderr, "  -i: specify Linux interface (e.g. eth0) or ExaNIC port name (e.g. exanic0:0)\n");

--- a/util/exanic-capture.c
+++ b/util/exanic-capture.c
@@ -469,7 +469,6 @@ struct exanic_rx_context
 
 int main(int argc, char *argv[])
 {
-    const char *interface = NULL;
     const char *savefile = NULL;
     FILE *savefp = NULL;
     struct exanic_rx_context rx_ctxs[EXA_MAX_IFACES];
@@ -624,7 +623,7 @@ int main(int argc, char *argv[])
 
         if (rx_size < 0 && status == EXANIC_RX_FRAME_OK)
         {
-            rx_ctx_idx = (++rx_ctx_idx) % rx_ctxs_no;
+            rx_ctx_idx = (rx_ctx_idx + 1) % rx_ctxs_no;
             continue;
         }
 
@@ -737,10 +736,10 @@ err_acquire_rx:
             set_promiscuous_mode(rx_ctxs[i].exanic, rx_ctxs[i].port_number, 0);
 
         if (rx_ctxs[i].rx)
-            exanic_release_rx_buffer(rx);
+            exanic_release_rx_buffer(rx_ctxs[i].rx);
 
         if (rx_ctxs[i].exanic)
-            exanic_release_handle(exanic);
+            exanic_release_handle(rx_ctxs[i].exanic);
     }
 err_acquire_handle:
     if (savefp != NULL)

--- a/util/exanic-config.c
+++ b/util/exanic-config.c
@@ -938,6 +938,7 @@ int set_local_loopback(const char * device, int port_number, int enable)
 {
     exanic_t *exanic = acquire_handle(device);
     exanic_hardware_id_t hw_type = exanic_get_hw_type(exanic);
+    int loopback;
 
     if ((hw_type == EXANIC_HW_X4) || (hw_type == EXANIC_HW_X2))
     {
@@ -975,6 +976,13 @@ int set_local_loopback(const char * device, int port_number, int enable)
             flags = flags & (~EXANIC_PORT_FLAG_LOOPBACK);
 
         exanic_register_write(exanic, REG_PORT_INDEX(port_number, REG_PORT_FLAGS), flags);
+    }
+
+    loopback = get_local_loopback(exanic, port_number);
+    if ((loopback == -1) || (enable && !loopback) || (!enable && loopback))
+    {
+        fprintf(stderr, "%s:%d: failed to update loopback mode: not supported by firmware?\n", device, port_number);
+        goto out;
     }
 
     printf("%s:%d: local-loopback mode %s\n", device, port_number,


### PR DESCRIPTION
Sometimes it's nice to be able to write few streams into one file easily.

This assumes the same filter to be applied to all interfaces. Is it correct to create a filter buffer per interface?