### PR TITLE
eliminate high-latency IDIV CPU instruction

### DIFF
--- a/libs/exanic/time.c
+++ b/libs/exanic/time.c
@@ -71,9 +71,7 @@ void exanic_cycles_to_timespec(exanic_t *exanic, exanic_cycles_t cycles,
 
 int64_t exanic_cycles_to_ns(exanic_t *exanic, exanic_cycles_t cycles)
 {
-    struct timespec ts;
-    exanic_cycles_to_timespec(exanic, cycles, &ts);
-    return ts.tv_sec * NANOS_PER_SEC + ts.tv_nsec;
+    return cycles * NANOS_PER_SEC / exanic->tick_hz;
 }
 
 int64_t exanic_cycles_to_ps(exanic_t *exanic, exanic_cycles_t cycles,


### PR DESCRIPTION
Simplifies disassembly as follows. The IDIV is 56 
```
exanic_cycles_to_ns:
        imul    rax, rsi, 1000000000
        mov     ecx, DWORD PTR 104[rdi]
        xor     edx, edx
        div     rcx
        ret
exanic_cycles_to_ns_orig:
        mov     ecx, DWORD PTR 104[rdi]
        mov     rax, rsi
        xor     edx, edx
        div     rcx
        mov     rsi, rax
        imul    rax, rdx, 1000000000
        xor     edx, edx
        imul    rsi, rsi, 1000000000
        div     rcx
        add     rax, rsi
        ret
```