### PR TITLE
examples: add unistd.h include for ssize_t

### DIFF
--- a/examples/exanic/exanic-benchmarker.c
+++ b/examples/exanic/exanic-benchmarker.c
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <time.h>
 #include <getopt.h>
+#include <unistd.h>
 
 #include <exanic/exanic.h>
 #include <exanic/fifo_tx.h>

--- a/examples/exanic/exanic-rx-chunk-inplace.c
+++ b/examples/exanic/exanic-rx-chunk-inplace.c
@@ -6,6 +6,7 @@
 
 #include <stdio.h>
 #include <time.h>
+#include <unistd.h>
 
 #include <exanic/exanic.h>
 #include <exanic/fifo_rx.h>


### PR DESCRIPTION
This failed to compile on my machine due to the lack of this header.