### PR TITLE
Support network namespaces in exasock

### DIFF
--- a/modules/exasock/exasock-dst.c
+++ b/modules/exasock/exasock-dst.c
@@ -13,6 +13,7 @@
 #include <linux/if_vlan.h>
 #include <linux/ip.h>
 #include <linux/tcp.h>
+#include <net/netns/generic.h>
 #include <net/arp.h>
 #include <net/route.h>
 
@@ -89,34 +90,41 @@ struct exasock_dst_queue_entry
     struct list_head    list;
 };
 
-static struct exasock_dst_entry **dst_table;
-static size_t                   dst_table_size;
-static struct list_head         dst_entries; /* Sorted by last used time */
-static struct list_head *       dst_neigh_hash;
-static DEFINE_SPINLOCK(         dst_lock);
-static struct timer_list        dst_expiry_timer;
-static bool                     dst_expiry_timer_running;
+struct exasock_dst_net
+{
+    struct net               *net;
+    struct exasock_dst_entry **table;
+    size_t                   table_size;
+    struct list_head         entries; /* Sorted by last used time */
+    struct list_head *       neigh_hash;
+    spinlock_t               lock;
+    struct timer_list        expiry_timer;
+    bool                     expiry_timer_running;
 
-/* Shared memory for user to notify kernel of exa_dst_entry usage */
-static uint8_t *                dst_used_flags;
+    /* Shared memory for user to notify kernel of exa_dst_entry usage */
+    uint8_t *                used_flags;
 
-/* User-visible copy of the destination table */
-static struct exa_dst_entry *   dst_user_table;
+    /* User-visible copy of the destination table */
+    struct exa_dst_entry     *user_table;
+};
+
+int exasock_dst_net_id __read_mostly;
 
 static void __update_user_dst_entry(
+                                    struct exasock_dst_net *en,
 #ifndef __HAS_RT_TABLE_ID
                                     bool default_rt,
 #endif
                                     unsigned int idx)
 {
-    if (dst_table[idx])
+    if (en->table[idx])
     {
-        struct neighbour *neigh = dst_table[idx]->neigh;
+        struct neighbour *neigh = en->table[idx]->neigh;
 #if defined(__HAS_OLD_NETCORE) || defined(__HAS_RT_TABLE_ID)
-        struct rtable *rt = dst_table[idx]->rt;
+        struct rtable *rt = en->table[idx]->rt;
 #endif
 #ifndef __HAS_OLD_NETCORE
-        struct flowi4 fl4 = dst_table[idx]->fl4;
+        struct flowi4 fl4 = en->table[idx]->fl4;
         uint32_t dst_addr = fl4.daddr;
         uint32_t src_addr = fl4.saddr;
 #else
@@ -124,21 +132,21 @@ static void __update_user_dst_entry(
         uint32_t src_addr = rt->rt_src;
 #endif
 
-        if (dst_user_table[idx].dst_addr == dst_addr &&
-            dst_user_table[idx].src_addr == src_addr &&
-            memcmp(dst_user_table[idx].eth_addr, neigh->ha, ETH_ALEN) == 0)
+        if (en->user_table[idx].dst_addr == dst_addr &&
+            en->user_table[idx].src_addr == src_addr &&
+            memcmp(en->user_table[idx].eth_addr, neigh->ha, ETH_ALEN) == 0)
         {
             /* Avoid invalidating caches if no change */
             return;
         }
 
         /* Tell user processes to skip over this entry */
-        dst_user_table[idx].state = EXA_DST_ENTRY_INVALID;
+        en->user_table[idx].state = EXA_DST_ENTRY_INVALID;
 
-        dst_user_table[idx].dst_addr = dst_addr;
-        dst_user_table[idx].src_addr = src_addr;
-        memcpy(dst_user_table[idx].eth_addr, neigh->ha, ETH_ALEN);
-        dst_user_table[idx].def_rt =
+        en->user_table[idx].dst_addr = dst_addr;
+        en->user_table[idx].src_addr = src_addr;
+        memcpy(en->user_table[idx].eth_addr, neigh->ha, ETH_ALEN);
+        en->user_table[idx].def_rt =
 #ifdef __HAS_RT_TABLE_ID
             (rt->rt_table_id == RT_TABLE_MAIN ||
              rt->rt_table_id == RT_TABLE_DEFAULT) ? 1 : 0;
@@ -146,23 +154,23 @@ static void __update_user_dst_entry(
             default_rt ? 1 : 0;
 #endif
         if (neigh->nud_state & NUD_VALID)
-            dst_user_table[idx].state = EXA_DST_ENTRY_VALID;
+            en->user_table[idx].state = EXA_DST_ENTRY_VALID;
         else
-            dst_user_table[idx].state = EXA_DST_ENTRY_INCOMPLETE;
+            en->user_table[idx].state = EXA_DST_ENTRY_INCOMPLETE;
 
         /* This will cause anyone who has cached this entry to refresh */
-        dst_user_table[idx].gen_id++;
+        en->user_table[idx].gen_id++;
     }
     else
     {
-        if (dst_user_table[idx].state == EXA_DST_ENTRY_EMPTY)
+        if (en->user_table[idx].state == EXA_DST_ENTRY_EMPTY)
             return;
 
-        dst_user_table[idx].state = EXA_DST_ENTRY_EMPTY;
-        dst_user_table[idx].dst_addr = 0;
-        dst_user_table[idx].src_addr = 0;
-        memset(dst_user_table[idx].eth_addr, 0, ETH_ALEN);
-        dst_user_table[idx].gen_id++;
+        en->user_table[idx].state = EXA_DST_ENTRY_EMPTY;
+        en->user_table[idx].dst_addr = 0;
+        en->user_table[idx].src_addr = 0;
+        memset(en->user_table[idx].eth_addr, 0, ETH_ALEN);
+        en->user_table[idx].gen_id++;
     }
 }
 
@@ -189,242 +197,90 @@ static void __free_dst_entry(struct exasock_dst_entry *de)
 }
 
 /* Find entry, returns next empty entry if not found, lock must be held */
-static unsigned int __find_dst_entry(uint32_t daddr, uint32_t saddr)
+static unsigned int __find_dst_entry(struct exasock_dst_net *en, uint32_t daddr, uint32_t saddr)
 {
     unsigned int hash, idx;
 
-    hash = idx = exa_dst_hash(daddr) & (dst_table_size - 1);
+    hash = idx = exa_dst_hash(daddr) & (en->table_size - 1);
     while (true)
     {
-        if (dst_table[idx] == NULL ||
+        if (en->table[idx] == NULL ||
 #ifndef __HAS_OLD_NETCORE
-            (dst_table[idx]->fl4.daddr == daddr &&
-             dst_table[idx]->fl4.saddr == saddr))
+            (en->table[idx]->fl4.daddr == daddr &&
+             en->table[idx]->fl4.saddr == saddr))
 #else
-            (dst_table[idx]->rt->rt_dst == daddr &&
-             dst_table[idx]->rt->rt_src == saddr))
+            (en->table[idx]->rt->rt_dst == daddr &&
+             en->table[idx]->rt->rt_src == saddr))
 #endif
             return idx;
 
-        idx = (idx + 1) & (dst_table_size - 1);
+        idx = (idx + 1) & (en->table_size - 1);
         if (idx == hash)
             return ~0;
     }
 }
 
 /* Update timer to fire at the expiry of the next entry, lock must be held */
-static void __update_dst_expiry_timer(void)
+static void __update_dst_expiry_timer(struct exasock_dst_net *en)
 {
     struct exasock_dst_entry *de;
 
-    if (dst_expiry_timer_running && !list_empty(&dst_entries))
+    if (en->expiry_timer_running && !list_empty(&en->entries))
     {
-        de = list_first_entry(&dst_entries, struct exasock_dst_entry, list);
-        mod_timer(&dst_expiry_timer, de->used + DST_EXPIRY_TIME);
+        de = list_first_entry(&en->entries, struct exasock_dst_entry, list);
+        mod_timer(&en->expiry_timer, de->used + DST_EXPIRY_TIME);
     }
 }
 
 /* Remove an entry from the hash table, lock must be held */
-static void __remove_dst_entry(unsigned int idx)
+static void __remove_dst_entry(struct exasock_dst_net *en, unsigned int idx)
 {
     unsigned int empty_idx, hash_idx;
     uint32_t daddr;
 
     /* Remove the hash table entry */
-    dst_table[idx] = NULL;
+    en->table[idx] = NULL;
     empty_idx = idx;
 
     /* Shuffle entries up if necessary */
     while (true)
     {
-        idx = (idx + 1) & (dst_table_size - 1);
+        idx = (idx + 1) & (en->table_size - 1);
 
-        if (!dst_table[idx])
+        if (!en->table[idx])
             break;
 
 #ifndef __HAS_OLD_NETCORE
-        daddr = dst_table[idx]->fl4.daddr;
+        daddr = en->table[idx]->fl4.daddr;
 #else
-        daddr = dst_table[idx]->rt->rt_dst;
+        daddr = en->table[idx]->rt->rt_dst;
 #endif
-        hash_idx = exa_dst_hash(daddr) & (dst_table_size - 1);
+        hash_idx = exa_dst_hash(daddr) & (en->table_size - 1);
 
-        if (((idx - hash_idx) & (dst_table_size - 1)) >=
-            ((idx - empty_idx) & (dst_table_size - 1)))
+        if (((idx - hash_idx) & (en->table_size - 1)) >=
+            ((idx - empty_idx) & (en->table_size - 1)))
         {
-            dst_table[empty_idx] = dst_table[idx];
-            dst_table[empty_idx]->idx = empty_idx;
-            dst_table[idx] = NULL;
-            __update_user_dst_entry(
+            en->table[empty_idx] = en->table[idx];
+            en->table[empty_idx]->idx = empty_idx;
+            en->table[idx] = NULL;
+            __update_user_dst_entry(en,
 #ifndef __HAS_RT_TABLE_ID
-                                    dst_table[empty_idx]->default_rt,
+                                    en->table[empty_idx]->default_rt,
 #endif
                                     empty_idx);
             empty_idx = idx;
         }
     }
 
-    __update_user_dst_entry(
+    __update_user_dst_entry(en,
 #ifndef __HAS_RT_TABLE_ID
                             false,
 #endif
                             empty_idx);
 }
 
-/* Check first entry in the list, remove if expired and adjust the table */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
-static void dst_expiry_timer_handler(struct timer_list *t)
-#else
-static void dst_expiry_timer_handler(unsigned long data)
-#endif
-{
-    struct neighbour *new_neigh;
-    struct exasock_dst_entry *de;
-
-    spin_lock_bh(&dst_lock);
-
-    if (list_empty(&dst_entries))
-    {
-        __update_dst_expiry_timer();
-        spin_unlock_bh(&dst_lock);
-        return;
-    }
-
-    /* Get first entry in dst_entries list */
-    de = list_first_entry(&dst_entries, struct exasock_dst_entry, list);
-
-    BUG_ON(dst_table[de->idx] != de);
-
-    if (time_after(de->used + DST_EXPIRY_TIME, jiffies))
-    {
-        /* Entry is not expiring yet - timer fired unexpectedly? */
-        __update_dst_expiry_timer();
-        spin_unlock_bh(&dst_lock);
-        return;
-    }
-
-    /* Remove the entry if not used since last check */
-    if (!dst_used_flags[de->idx])
-        goto remove_entry;
-    dst_used_flags[de->idx] = 0;
-
-    /* Check route to see if it is stale */
-#if __HAS_RT_GENID_GETTER_IPV4
-    if (rt_genid_ipv4(dev_net(rtable_dst(de->rt).dev)) != de->rt->rt_genid)
-#elif __HAS_RT_GENID_GETTER
-    if (rt_genid(dev_net(rtable_dst(de->rt).dev)) != de->rt->rt_genid)
-#else
-    if (atomic_read(&dev_net(rtable_dst(de->rt).dev)->ipv4.rt_genid) !=
-        de->rt->rt_genid)
-#endif
-    {
-#ifndef __HAS_OLD_NETCORE
-        struct flowi4 fl4 = { .daddr = de->fl4.daddr, .saddr = de->fl4.saddr };
-#else
-        struct flowi fl = {
-            .nl_u = {
-                .ip4_u = { .daddr = de->rt->rt_dst, .saddr = de->rt->rt_src },
-            },
-        };
-#endif
-        unsigned int hash;
-
-        /* Release old neigbour and route cache entry */
-        exasock_dst_neigh_release(de->neigh);
-        de->neigh = NULL;
-        ip_rt_put(de->rt);
-
-        /* Get new route from routing table */
-#ifndef __HAS_OLD_NETCORE
-        de->rt = __ip_route_output_key(&init_net, &fl4);
-        if (IS_ERR(de->rt))
-#else
-        if (__ip_route_output_key(&init_net, &de->rt, &fl) != 0)
-#endif
-        {
-            de->rt = NULL;
-            goto remove_entry;
-        }
-
-        new_neigh = exasock_dst_neigh_lookup(&rtable_dst(de->rt), &fl4.daddr);
-        de->neigh = new_neigh;
-        hash = hash_ptr(new_neigh, NEIGH_HASH_BITS);
-        list_del(&de->neigh_hash);
-        list_add_tail(&de->neigh_hash, &dst_neigh_hash[hash]);
-        __update_user_dst_entry(
-#ifndef __HAS_RT_TABLE_ID
-                                de->default_rt,
-#endif
-                                de->idx);
-    }
-
-    /* Update last used time of entry */
-    de->used = jiffies;
-    list_del(&de->list);
-    list_add_tail(&de->list, &dst_entries);
-    __update_dst_expiry_timer();
-
-    spin_unlock_bh(&dst_lock);
-
-    /* Update Linux neighbour table usage */
-    neigh_event_send(de->neigh, NULL);
-    return;
-
-remove_entry:
-    list_del(&de->list);
-    list_del(&de->neigh_hash);
-    __remove_dst_entry(de->idx);
-    __update_dst_expiry_timer();
-
-    spin_unlock_bh(&dst_lock);
-
-    __free_dst_entry(de);
-}
-
-/* Remove any packets pending in destination table queue related to a given
- * connection */
-void exasock_dst_remove_socket(uint32_t local_addr, uint32_t peer_addr,
-                               uint16_t local_port, uint16_t peer_port)
-{
-    struct exasock_dst_queue_entry *qe, *tmp;
-    struct exasock_dst_entry *de;
-    unsigned idx;
-
-    spin_lock_bh(&dst_lock);
-
-    idx = __find_dst_entry(peer_addr, local_addr);
-    if ((idx == ~0) || dst_table[idx] == NULL)
-        goto exit;
-
-    de = dst_table[idx];
-
-    list_for_each_entry_safe(qe, tmp, &de->dst_queue, list)
-    {
-        struct sk_buff *skb = qe->skb;
-        struct iphdr *iph;
-        struct tcphdr *th;
-
-        iph = (struct iphdr *)skb->data;
-        if (iph->protocol != IPPROTO_TCP)
-            continue;
-        th = (struct tcphdr *)(skb->data + iph->ihl * 4);
-        if ((iph->saddr == local_addr) && (iph->daddr == peer_addr) &&
-            (th->source == local_port) && (th->dest == peer_port))
-        {
-            dev_put(skb->dev);
-            kfree_skb(skb);
-            list_del(&qe->list);
-            kfree(qe);
-        }
-    }
-exit:
-    spin_unlock_bh(&dst_lock);
-}
-
-/**
- * Update a table entry after a neighbour reply.
- */
-void exasock_dst_neigh_update(struct neighbour *neigh)
+/* Update a table entry after a neighbour reply */
+static void __neigh_update(struct exasock_dst_net *en, struct neighbour *neigh)
 {
     struct exasock_dst_entry *de;
     struct exasock_dst_queue_entry *qe, *tmp;
@@ -434,14 +290,14 @@ void exasock_dst_neigh_update(struct neighbour *neigh)
     if (!(neigh->nud_state & NUD_VALID))
         return;
 
-    spin_lock_bh(&dst_lock);
+    spin_lock_bh(&en->lock);
 
     hash = hash_ptr(neigh, NEIGH_HASH_BITS);
-    list_for_each_entry(de, &dst_neigh_hash[hash], neigh_hash)
+    list_for_each_entry(de, &en->neigh_hash[hash], neigh_hash)
     {
         if (de->neigh == neigh)
         {
-            __update_user_dst_entry(
+            __update_user_dst_entry(en,
 #ifndef __HAS_RT_TABLE_ID
                                     de->default_rt,
 #endif
@@ -492,17 +348,187 @@ void exasock_dst_neigh_update(struct neighbour *neigh)
         kfree(qe);
     }
 
-    spin_unlock_bh(&dst_lock);
+    spin_unlock_bh(&en->lock);
 
     BUG_ON(!list_empty(&temp_head));
+}
+
+
+/* Check first entry in the list, remove if expired and adjust the table */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
+static void dst_expiry_timer_handler(struct timer_list *t)
+#else
+static void dst_expiry_timer_handler(unsigned long data)
+#endif
+{
+    struct exasock_dst_net *en =
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
+        from_timer(exasock_dst_net, t, expiry_timer);
+#else
+        (struct exasock_dst_net *)data;
+#endif
+    struct neighbour *new_neigh;
+    struct exasock_dst_entry *de;
+
+    spin_lock_bh(&en->lock);
+
+    if (list_empty(&en->entries))
+    {
+        __update_dst_expiry_timer(en);
+        spin_unlock_bh(&en->lock);
+        return;
+    }
+
+    /* Get first entry in dst_entries list */
+    de = list_first_entry(&en->entries, struct exasock_dst_entry, list);
+
+    BUG_ON(en->table[de->idx] != de);
+
+    if (time_after(de->used + DST_EXPIRY_TIME, jiffies))
+    {
+        /* Entry is not expiring yet - timer fired unexpectedly? */
+        __update_dst_expiry_timer(en);
+        spin_unlock_bh(&en->lock);
+        return;
+    }
+
+    /* Remove the entry if not used since last check */
+    if (!en->used_flags[de->idx])
+        goto remove_entry;
+    en->used_flags[de->idx] = 0;
+
+    /* Check route to see if it is stale */
+#if __HAS_RT_GENID_GETTER_IPV4
+    if (rt_genid_ipv4(dev_net(rtable_dst(de->rt).dev)) != de->rt->rt_genid)
+#elif __HAS_RT_GENID_GETTER
+    if (rt_genid(dev_net(rtable_dst(de->rt).dev)) != de->rt->rt_genid)
+#else
+    if (atomic_read(&dev_net(rtable_dst(de->rt).dev)->ipv4.rt_genid) !=
+        de->rt->rt_genid)
+#endif
+    {
+#ifndef __HAS_OLD_NETCORE
+        struct flowi4 fl4 = { .daddr = de->fl4.daddr, .saddr = de->fl4.saddr };
+#else
+        struct flowi fl = {
+            .nl_u = {
+                .ip4_u = { .daddr = de->rt->rt_dst, .saddr = de->rt->rt_src },
+            },
+        };
+#endif
+        unsigned int hash;
+
+        /* Release old neigbour and route cache entry */
+        exasock_dst_neigh_release(de->neigh);
+        de->neigh = NULL;
+        ip_rt_put(de->rt);
+
+        /* Get new route from routing table */
+#ifndef __HAS_OLD_NETCORE
+        de->rt = __ip_route_output_key(en->net, &fl4);
+        if (IS_ERR(de->rt))
+#else
+        if (__ip_route_output_key(en->net, &de->rt, &fl) != 0)
+#endif
+        {
+            de->rt = NULL;
+            goto remove_entry;
+        }
+
+        new_neigh = exasock_dst_neigh_lookup(&rtable_dst(de->rt), &fl4.daddr);
+        de->neigh = new_neigh;
+        hash = hash_ptr(new_neigh, NEIGH_HASH_BITS);
+        list_del(&de->neigh_hash);
+        list_add_tail(&de->neigh_hash, &en->neigh_hash[hash]);
+        __update_user_dst_entry(en,
+#ifndef __HAS_RT_TABLE_ID
+                                de->default_rt,
+#endif
+                                de->idx);
+    }
+
+    /* Update last used time of entry */
+    de->used = jiffies;
+    list_del(&de->list);
+    list_add_tail(&de->list, &en->entries);
+    __update_dst_expiry_timer(en);
+
+    spin_unlock_bh(&en->lock);
+
+    /* Update Linux neighbour table usage */
+    neigh_event_send(de->neigh, NULL);
+    return;
+
+remove_entry:
+    list_del(&de->list);
+    list_del(&de->neigh_hash);
+    __remove_dst_entry(en, de->idx);
+    __update_dst_expiry_timer(en);
+
+    spin_unlock_bh(&en->lock);
+
+    __free_dst_entry(de);
+}
+
+/* Remove any packets pending in destination table queue related to a given
+ * connection */
+void exasock_dst_remove_socket(struct net *net,
+                               uint32_t local_addr, uint32_t peer_addr,
+                               uint16_t local_port, uint16_t peer_port)
+{
+    struct exasock_dst_net *en = net_generic(net, exasock_dst_net_id);
+    struct exasock_dst_queue_entry *qe, *tmp;
+    struct exasock_dst_entry *de;
+    unsigned idx;
+
+    spin_lock_bh(&en->lock);
+
+    idx = __find_dst_entry(en, peer_addr, local_addr);
+    if ((idx == ~0) || en->table[idx] == NULL)
+        goto exit;
+
+    de = en->table[idx];
+
+    list_for_each_entry_safe(qe, tmp, &de->dst_queue, list)
+    {
+        struct sk_buff *skb = qe->skb;
+        struct iphdr *iph;
+        struct tcphdr *th;
+
+        iph = (struct iphdr *)skb->data;
+        if (iph->protocol != IPPROTO_TCP)
+            continue;
+        th = (struct tcphdr *)(skb->data + iph->ihl * 4);
+        if ((iph->saddr == local_addr) && (iph->daddr == peer_addr) &&
+            (th->source == local_port) && (th->dest == peer_port))
+        {
+            dev_put(skb->dev);
+            kfree_skb(skb);
+            list_del(&qe->list);
+            kfree(qe);
+        }
+    }
+exit:
+    spin_unlock_bh(&en->lock);
+}
+
+/**
+ * Update a table entry after a neighbour reply.
+ */
+void exasock_dst_neigh_update(struct net *net, struct neighbour *neigh)
+{
+    struct exasock_dst_net *en = net_generic(net, exasock_dst_net_id);
+    __neigh_update(en, neigh);
 }
 
 /**
  * Look up or create destination entry and insert skb into queue.
  */
-int exasock_dst_insert(uint32_t dst_addr, uint32_t *src_addr,
+int exasock_dst_insert(struct net *net,
+                       uint32_t dst_addr, uint32_t *src_addr,
                        struct sk_buff *skb)
 {
+    struct exasock_dst_net *en = net_generic(net, exasock_dst_net_id);
     struct exasock_dst_entry *de;
     struct exasock_dst_queue_entry *qe;
     struct net_device *ndev, *realdev;
@@ -523,11 +549,11 @@ int exasock_dst_insert(uint32_t dst_addr, uint32_t *src_addr,
 
     /* Determine output interface */
 #ifndef __HAS_OLD_NETCORE
-    rt = __ip_route_output_key(&init_net, &fl4);
+    rt = __ip_route_output_key(en->net, &fl4);
     if (IS_ERR(rt))
 #else
     rt = NULL;
-    err = __ip_route_output_key(&init_net, &rt, &fl);
+    err = __ip_route_output_key(en->net, &rt, &fl);
     if (err)
 #endif
     {
@@ -542,7 +568,7 @@ int exasock_dst_insert(uint32_t dst_addr, uint32_t *src_addr,
     saddr = rt->rt_src;
     oif = rt->rt_iif;
 #endif
-    ndev = dev_get_by_index(&init_net, oif);
+    ndev = dev_get_by_index(en->net, oif);
     if (ndev == NULL)
     {
         err = -ENETUNREACH;
@@ -588,20 +614,20 @@ int exasock_dst_insert(uint32_t dst_addr, uint32_t *src_addr,
         ndev = NULL;
     }
 
-    spin_lock_bh(&dst_lock);
+    spin_lock_bh(&en->lock);
 
-    idx = __find_dst_entry(dst_addr, saddr);
+    idx = __find_dst_entry(en, dst_addr, saddr);
 
     if (idx == ~0)
     {
         err = -ENOMEM;
         goto err_find_dst_entry;
     }
-    else if (dst_table[idx])
+    else if (en->table[idx])
     {
         /* Existing entry */
         kfree(de);
-        de = dst_table[idx];
+        de = en->table[idx];
         list_del(&de->list);
     }
     else
@@ -619,43 +645,43 @@ int exasock_dst_insert(uint32_t dst_addr, uint32_t *src_addr,
         de->idx = idx;
         INIT_LIST_HEAD(&de->dst_queue);
         hash = hash_ptr(de->neigh, NEIGH_HASH_BITS);
-        list_add_tail(&de->neigh_hash, &dst_neigh_hash[hash]);
-        dst_table[idx] = de;
-        __update_user_dst_entry(
+        list_add_tail(&de->neigh_hash, &en->neigh_hash[hash]);
+        en->table[idx] = de;
+        __update_user_dst_entry(en,
 #ifndef __HAS_RT_TABLE_ID
                                 de->default_rt,
 #endif
                                 idx);
     }
 
-    dst_used_flags[idx] = 0;
+    en->used_flags[idx] = 0;
     de->used = jiffies;
 #ifndef __HAS_RT_TABLE_ID
     if (*src_addr == htonl(INADDR_ANY))
         de->default_rt = true;
 #endif
-    list_add_tail(&de->list, &dst_entries);
+    list_add_tail(&de->list, &en->entries);
 
     if (qe)
         list_add_tail(&qe->list, &de->dst_queue);
 
-    __update_dst_expiry_timer();
+    __update_dst_expiry_timer(en);
 
-    spin_unlock_bh(&dst_lock);
+    spin_unlock_bh(&en->lock);
 
     /* Initiate lookup using Linux neighbour cache */
     neigh_event_send(de->neigh, NULL);
 
     /* Packet could have been queued even though neigh is valid */
     if (de->neigh->nud_state & NUD_VALID)
-        exasock_dst_neigh_update(de->neigh);
+        __neigh_update(en, de->neigh);
 
     *src_addr = saddr;
 
     return 0;
 
 err_find_dst_entry:
-    spin_unlock_bh(&dst_lock);
+    spin_unlock_bh(&en->lock);
     kfree(qe);
 err_queue_alloc:
     kfree(de);
@@ -673,19 +699,20 @@ err_ip_route:
 /**
  * Remove all table entries which contain source address src_addr
  */
-void exasock_dst_invalidate_src(uint32_t src_addr)
+void exasock_dst_invalidate_src(struct net *net, uint32_t src_addr)
 {
+    struct exasock_dst_net *en = net_generic(net, exasock_dst_net_id);
     struct exasock_dst_entry *de;
     unsigned int idx;
 
-    for (idx = 0; idx < dst_table_size; idx++)
+    for (idx = 0; idx < en->table_size; idx++)
     {
         /* Read the user table to avoid having to take a lock
          * unless we find a match */
-        if (dst_user_table[idx].src_addr == src_addr)
+        if (en->user_table[idx].src_addr == src_addr)
         {
-            spin_lock_bh(&dst_lock);
-            de = dst_table[idx];
+            spin_lock_bh(&en->lock);
+            de = en->table[idx];
             if (de != NULL &&
 #ifndef __HAS_OLD_NETCORE
                 de->fl4.saddr == src_addr)
@@ -696,79 +723,124 @@ void exasock_dst_invalidate_src(uint32_t src_addr)
                 /* Found a match, remove the table entry */
                 list_del(&de->list);
                 list_del(&de->neigh_hash);
-                __remove_dst_entry(idx);
-                spin_unlock_bh(&dst_lock);
+                __remove_dst_entry(en, idx);
+                spin_unlock_bh(&en->lock);
                 __free_dst_entry(de);
             }
             else
-                spin_unlock_bh(&dst_lock);
+                spin_unlock_bh(&en->lock);
         }
     }
 }
 
-int exasock_dst_used_flags_mmap(struct vm_area_struct *vma)
+int exasock_dst_used_flags_mmap(struct net *net, struct vm_area_struct *vma)
 {
-    return remap_vmalloc_range(vma, dst_used_flags,
+    struct exasock_dst_net *en = net_generic(net, exasock_dst_net_id);
+    return remap_vmalloc_range(vma, en->used_flags,
             vma->vm_pgoff - (EXASOCK_OFFSET_DST_USED_FLAGS / PAGE_SIZE));
 }
 
-int exasock_dst_table_mmap(struct vm_area_struct *vma)
+int exasock_dst_table_mmap(struct net *net, struct vm_area_struct *vma)
 {
+    struct exasock_dst_net *en = net_generic(net, exasock_dst_net_id);
+
     if (vma->vm_flags & VM_WRITE)
         return -EACCES;
 
-    return remap_vmalloc_range(vma, dst_user_table,
+    return remap_vmalloc_range(vma, en->user_table,
             vma->vm_pgoff - (EXASOCK_OFFSET_DST_TABLE / PAGE_SIZE));
 }
 
-unsigned int exasock_dst_table_size(void)
+unsigned int exasock_dst_table_size(struct net *net)
 {
-    return dst_table_size;
+    struct exasock_dst_net *en = net_generic(net, exasock_dst_net_id);
+    return en->table_size;
 }
+
+static int __net_init exasock_dst_net_init(struct net *net)
+{
+    struct exasock_dst_net *en = net_generic(net, exasock_dst_net_id);
+    unsigned i;
+    int err;
+
+    en->table_size = DEFAULT_DST_TABLE_SIZE;
+    en->table = kcalloc(en->table_size, sizeof(struct exasock_dst_entry *),
+            GFP_KERNEL);
+    en->neigh_hash = kmalloc(NEIGH_HASH_SIZE * sizeof(struct list_head),
+            GFP_KERNEL);
+    en->used_flags = vmalloc_user(en->table_size * sizeof(uint8_t));
+    en->user_table = vmalloc_user(en->table_size *
+            sizeof(struct exa_dst_entry));
+
+    if (en->table == NULL || en->neigh_hash == NULL ||
+        en->used_flags == NULL || en->user_table == NULL)
+    {
+        err = -ENOMEM;
+        goto err_alloc;
+    }
+
+    INIT_LIST_HEAD(&en->entries);
+    for (i = 0; i < NEIGH_HASH_SIZE; i++)
+        INIT_LIST_HEAD(&en->neigh_hash[i]);
+
+    spin_lock_init(&en->lock);
+    en->net = net;
+    en->expiry_timer_running = true;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
+    timer_setup(&en->expiry_timer, dst_expiry_timer_handler, 0);
+#else
+    setup_timer(&en->expiry_timer, dst_expiry_timer_handler, (unsigned long)en);
+#endif
+    return 0;
+
+err_alloc:
+    vfree(en->user_table);
+    vfree(en->used_flags);
+    kfree(en->neigh_hash);
+    kfree(en->table);
+    return err;
+}
+
+static void __net_exit exasock_dst_net_exit(struct net *net)
+{
+    struct exasock_dst_net *en = net_generic(net, exasock_dst_net_id);
+    struct exasock_dst_entry *de, *tmp;
+
+    en->expiry_timer_running = false;
+    del_timer_sync(&en->expiry_timer);
+
+    spin_lock_bh(&en->lock);
+
+    list_for_each_entry_safe(de, tmp, &en->entries, list)
+    {
+        list_del(&de->list);
+        list_del(&de->neigh_hash);
+        en->table[de->idx] = NULL;
+        __free_dst_entry(de);
+    }
+
+    spin_unlock_bh(&en->lock);
+
+    kfree(en->table);
+    kfree(en->neigh_hash);
+    vfree(en->used_flags);
+    vfree(en->user_table);
+}
+
+static struct pernet_operations exasock_dst_net_ops = {
+    .init = exasock_dst_net_init,
+    .exit = exasock_dst_net_exit,
+    .id   = &exasock_dst_net_id,
+    .size = sizeof(struct exasock_dst_net),
+};
 
 /**
  * This function is called from exasock_init() when the driver is loaded.
  */
 int __init exasock_dst_init(void)
 {
-    unsigned i;
-    int err;
-
-    dst_table_size = DEFAULT_DST_TABLE_SIZE;
-    dst_table = kcalloc(dst_table_size, sizeof(struct exasock_dst_entry *),
-            GFP_KERNEL);
-    dst_neigh_hash = kmalloc(NEIGH_HASH_SIZE * sizeof(struct list_head),
-            GFP_KERNEL);
-    dst_used_flags = vmalloc_user(dst_table_size * sizeof(uint8_t));
-    dst_user_table = vmalloc_user(dst_table_size *
-            sizeof(struct exa_dst_entry));
-
-    if (dst_table == NULL || dst_neigh_hash == NULL ||
-        dst_used_flags == NULL || dst_user_table == NULL)
-    {
-        err = -ENOMEM;
-        goto err_alloc;
-    }
-
-    INIT_LIST_HEAD(&dst_entries);
-    for (i = 0; i < NEIGH_HASH_SIZE; i++)
-        INIT_LIST_HEAD(&dst_neigh_hash[i]);
-
-    dst_expiry_timer_running = true;
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
-    timer_setup(&dst_expiry_timer, dst_expiry_timer_handler, 0);
-#else
-    setup_timer(&dst_expiry_timer, dst_expiry_timer_handler, 0);
-#endif
-    return 0;
-
-err_alloc:
-    vfree(dst_user_table);
-    vfree(dst_used_flags);
-    kfree(dst_neigh_hash);
-    kfree(dst_table);
-    return err;
+    return register_pernet_subsys(&exasock_dst_net_ops);
 }
 
 /**
@@ -777,25 +849,5 @@ err_alloc:
  */
 void exasock_dst_exit(void)
 {
-    struct exasock_dst_entry *de, *tmp;
-
-    dst_expiry_timer_running = false;
-    del_timer_sync(&dst_expiry_timer);
-
-    spin_lock_bh(&dst_lock);
-
-    list_for_each_entry_safe(de, tmp, &dst_entries, list)
-    {
-        list_del(&de->list);
-        list_del(&de->neigh_hash);
-        dst_table[de->idx] = NULL;
-        __free_dst_entry(de);
-    }
-
-    spin_unlock_bh(&dst_lock);
-
-    kfree(dst_table);
-    kfree(dst_neigh_hash);
-    vfree(dst_used_flags);
-    vfree(dst_user_table);
+    unregister_pernet_subsys(&exasock_dst_net_ops);
 }

--- a/modules/exasock/exasock-ip.c
+++ b/modules/exasock/exasock-ip.c
@@ -18,7 +18,8 @@
 #include "../exanic/exanic.h"
 #include "exasock.h"
 
-int exasock_ip_send(uint8_t proto, uint32_t dst_addr, uint32_t src_addr,
+int exasock_ip_send(struct net *net,
+                    uint8_t proto, uint32_t dst_addr, uint32_t src_addr,
                     struct sk_buff *skb)
 {
     struct iphdr *iph;
@@ -38,5 +39,8 @@ int exasock_ip_send(uint8_t proto, uint32_t dst_addr, uint32_t src_addr,
 
     skb_reset_network_header(skb);
 
-    return exasock_dst_insert(dst_addr, &src_addr, skb);
+    if (net != NULL)
+        return exasock_dst_insert(net, dst_addr, &src_addr, skb);
+    else
+        return 0;
 }

--- a/modules/exasock/exasock.h
+++ b/modules/exasock/exasock.h
@@ -60,18 +60,21 @@ static inline void exasock_unlock(volatile uint32_t *flag)
 /* exasock-dst.c */
 int __init exasock_dst_init(void);
 void exasock_dst_exit(void);
-void exasock_dst_remove_socket(uint32_t local_addr, uint32_t peer_addr,
+void exasock_dst_remove_socket(struct net *net,
+                               uint32_t local_addr, uint32_t peer_addr,
                                uint16_t local_port, uint16_t peer_port);
-void exasock_dst_neigh_update(struct neighbour *neigh);
-int exasock_dst_insert(uint32_t dst_addr, uint32_t *src_addr,
+void exasock_dst_neigh_update(struct net *net, struct neighbour *neigh);
+int exasock_dst_insert(struct net *net,
+                       uint32_t dst_addr, uint32_t *src_addr,
                        struct sk_buff *skb);
-void exasock_dst_invalidate_src(uint32_t src_addr);
-int exasock_dst_used_flags_mmap(struct vm_area_struct *vma);
-int exasock_dst_table_mmap(struct vm_area_struct *vma);
-unsigned int exasock_dst_table_size(void);
+void exasock_dst_invalidate_src(struct net *net, uint32_t src_addr);
+int exasock_dst_used_flags_mmap(struct net *net, struct vm_area_struct *vma);
+int exasock_dst_table_mmap(struct net *net, struct vm_area_struct *vma);
+unsigned int exasock_dst_table_size(struct net *net);
 
 /* exasock-ip.c */
-int exasock_ip_send(uint8_t proto, uint32_t dst_addr, uint32_t src_addr,
+int exasock_ip_send(struct net *net,
+                    uint8_t proto, uint32_t dst_addr, uint32_t src_addr,
                     struct sk_buff *skb);
 
 /* exasock-udp.c */


### PR DESCRIPTION
This aims to introduce partial network namespaces support with minimal changes in the code.

The main challenge in implementing netns is that different processes (and sockets) can have different routing tables. Therefore exasock-dst tables must either be additionally indexed by netns inum or held separately for each namespace. Because my aim was to minimize performance impact of this addition I opted for a separate state which allows us to continue using 32-bit hashing.

Most fixes needed are various parts of the module now passing around network namespace structures. No userspace changes are needed now.

Current main limitation is that in several places it's still assumed that "socket namespace = process namespace" which is not necessarily true. To fix this we'd need to make userspace aware of socket's namespace and use tables accordingly. This would also require changes in several ioctls so that userspace can mmap several destination tables and request `exasock_dst_queue` for a given netns.

Another small edge case is that we no longer update destination table when we resend SEQ because this would mean we'll need to track network namespace in TCP requests -- IMO it's too much complex code for too little a gain.

Overall this is not a complete solution because of the reasons above but it improves things to the point where it covers most cases (containers, isolated processes etc.) with understandable patch and no hot path changes.