### PR TITLE
Handle ACKs from future by treating them as ACKs for all currently sent data

### DIFF
--- a/libs/exasock/tcp.h
+++ b/libs/exasock/tcp.h
@@ -654,6 +654,11 @@ exa_tcp_update_state(struct exa_tcp_conn * restrict ctx, uint8_t flags,
         uint32_t win_end = ack_seq +
                            (win << ((flags & TH_SYN) ? 0 : state->wscale));
         uint32_t rwnd_end = state->rwnd_end;
+        uint32_t send_seq = state->send_seq;
+
+        /* Check if ACK is from future; set ACK = SEQ in that case */
+        if (seq_compare(send_seq, ack_seq) < 0)
+            ack_seq = send_seq;
 
         /* Check if got ACK for more of our sent data */
         while (seq_compare(send_ack, ack_seq) < 0)

--- a/modules/exasock/exasock-tcp.c
+++ b/modules/exasock/exasock-tcp.c
@@ -1822,11 +1822,15 @@ static int exasock_tcp_conn_process(struct sk_buff *skb,
             /* Non-duplicate ACK */
             uint32_t send_ack = state->p.tcp.send_ack;
             uint32_t rwnd_end = state->p.tcp.rwnd_end;
+            uint32_t send_seq = state->p.tcp.send_seq;
 
             /* If this packet has not been processed by user space yet, kernel
              * needs to update TCP state with new ACK and/or receiver buffer
              * space.
              */
+            if (after(ack_seq, send_seq))
+                ack_seq = send_seq;
+
             while (after(ack_seq, send_ack))
                 send_ack = cmpxchg(&state->p.tcp.send_ack, send_ack, ack_seq);
             while (after(win_end, rwnd_end))


### PR DESCRIPTION
The following patch fixes case when remote host sends a packet which ACKs
part of a stream which was not yet made visible to exasock stack by
tcp_send_advance(). This could happen in case when the actual tx is done by
separate hw/thread and ack from remote host comes earlier then stack was
informed about this tx.

In current code stream state will just break because unacked stream size is
calculated as `send_seq - send_ack` which would overflow in that case. The
patch fixes it in one of most obvious ways -- by treating ACKs from future
as ACKs for all currently sent data.

This patch was sent long time before via Exablaze support channel; unfortunately we weren't able to continue the discussion at that time due to other tasks taking priority. Here's the support reply for reference:

>    Hi Dmitry,

>    I have taken a closer look at this patch and scenario you are describing. It looks like what is happening here is:
>    1. you are using exasock extension API to prepare a TCP segment (exasock_tcp_build_header/exasock_tcp_set_length/exasock_tcp_calc_checksum) and then sending this segment with libexanic.
>    2. exasock_tcp_send_advance() is not invoked right away for some reason, so exasock receives respective ACK from peer yet before TCP state gets updated with exasock_tcp_send_advance().
>    3. In the period between the point in which the ACK gets processed and exasock_tcp_send_advance() gets called, the state remains corrupted, since send_ack value is greater than send_seq.
>    4. exasock_tcp_send_advance() finally gets called, updating the state respectively.

>    Now, in order for this problem to manifest itself, there would need to be an attempt to send some more data yet before exasock_tcp_send_advance() gets called (between points 2. and 4.), so that exasock would try to calculate next segment length (exa_tcp_max_pkt_len()) resulting in corrupted unacked_len value.

>    Is this the case in your scenario, or you are reproducing the issue some other way?

>    If the issue is triggered by sending more data yet before exasock_tcp_send_advance() gets called, then the future ACK issue would be just a part of the problem. An attempt to send more data before updating the state would result in reusing sequence numbers already used for sending the previous data. To avoid this problem one would need to ensure that exasock_tcp_send_advance() gets called before any other data gets sent. In such a case the patch should not be needed anymore, since even when an ACK from future gets received, the state should get to normal as soon as updated with exasock_tcp_send_advance().

Our issue wasn't related to sending more data; it was because of the possible delay between sending data and calling `exasock_tcp_send_advance`. We caught a rare race condition when the remote client replied with ACK before we made this call, breakage of TCP stack state ensued. Test scenario:

1. exasock extension API is used to prepare a packet;
2. packet is sent using libexasock;
3. host sleeps; remote host replies with ACK;
4. kernel module tries to process a packet with ACK from the future and TCP state breaks.