### PR TITLE
getpeername should check if tcp connection has been fully established

### DIFF
--- a/libs/exasock/exanic.c
+++ b/libs/exasock/exanic.c
@@ -1530,6 +1530,14 @@ exanic_tcp_connecting(struct exa_socket * restrict sock)
 }
 
 bool
+exanic_tcp_established(struct exa_socket * restrict sock)
+{
+    struct exanic_tcp * restrict ctx = sock->ctx.tcp;
+
+    return exa_tcp_established(&ctx->tcp);
+}
+
+bool
 exanic_tcp_listening(struct exa_socket * restrict sock)
 {
     struct exanic_tcp * restrict ctx = sock->ctx.tcp;

--- a/libs/exasock/exanic.h
+++ b/libs/exasock/exanic.h
@@ -50,6 +50,7 @@ void exanic_tcp_connect(struct exa_socket * restrict sock,
 void exanic_tcp_shutdown_write(struct exa_socket * restrict sock);
 void exanic_tcp_reset(struct exa_socket * restrict sock);
 bool exanic_tcp_connecting(struct exa_socket * restrict sock);
+bool exanic_tcp_established(struct exa_socket * restrict sock);
 bool exanic_tcp_listening(struct exa_socket * restrict sock);
 bool exanic_tcp_writeable(struct exa_socket * restrict sock);
 bool exanic_tcp_write_closed(struct exa_socket *sock);

--- a/libs/exasock/socket/socket.c
+++ b/libs/exasock/socket/socket.c
@@ -1199,6 +1199,7 @@ int
 getpeername(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 {
     struct exa_socket * restrict sock = exa_socket_get(sockfd);
+    bool connected = false;
     int ret;
 
     TRACE_CALL("getpeername");
@@ -1209,7 +1210,10 @@ getpeername(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
     {
         exa_read_lock(&sock->lock);
 
-        if (!sock->connected)
+        connected = sock->connected;
+        if (SOCK_STREAM == sock->type)
+                connected = exanic_tcp_established(sock);
+        if (!connected)
         {
             errno = ENOTCONN;
             ret = -1;

--- a/libs/exasock/tcp.h
+++ b/libs/exasock/tcp.h
@@ -261,6 +261,14 @@ exa_tcp_connecting(struct exa_tcp_conn * restrict ctx)
            state->state == EXA_TCP_SYN_RCVD;
 }
 
+static inline bool
+exa_tcp_established(struct exa_tcp_conn * restrict ctx)
+{
+    struct exa_tcp_state * restrict state = &ctx->state->p.tcp;
+
+    return EXA_TCP_ESTABLISHED == state->state;
+}
+
 /* Return true if the write side of the connection has closed */
 static inline bool
 exa_tcp_write_closed(struct exa_tcp_conn * restrict ctx)


### PR DESCRIPTION
sock->connected is set to true before tcp connection is fully established