### PR TITLE
Correct recvmmsg

### DIFF
--- a/libs/exasock/socket/recv.c
+++ b/libs/exasock/socket/recv.c
@@ -1070,10 +1070,8 @@ recvmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen,
                              flags & ~MSG_WAITFORONE);
         if (ret == -1)
         {
-            /* no more data, and user wants non-blocking behaviour */
-            if (errno == EAGAIN
-                && (flags & MSG_WAITFORONE)
-                && (i > 0))
+            /* subsquent calls will return the error */
+            if (i > 0)
                 ret = i;
             goto out;
         }


### PR DESCRIPTION
If an error occurs after at least one message has been received, the
call succeeds, and returns the number of messages received. The
error code is expected to be returned on a subsequent call to
recvmmsg().