### PR TITLE
Fix ExaSock TCP seqnum off-by-one error in EXA_TCP_FIN_WAIT_2

### DIFF
--- a/libs/exasock/tcp.h
+++ b/libs/exasock/tcp.h
@@ -478,7 +478,7 @@ exa_tcp_build_ctrl(struct exa_tcp_conn * restrict ctx, char ** restrict hdr,
 
     case EXA_TCP_FIN_WAIT_2:
         /* Send ACK */
-        h->th_seq = htonl(state->send_seq);
+        h->th_seq = htonl(state->send_seq + 1);
         h->th_ack = htonl(recv_seq);
         h->th_flags = TH_ACK;
         PROFILE_INFO_TCP_TX_RX_EVENT(false, ctx, EXA_TCP_FIN_WAIT_2, 0, 1, state->send_seq, recv_seq);

--- a/modules/exasock/exasock-tcp.c
+++ b/modules/exasock/exasock-tcp.c
@@ -3817,7 +3817,8 @@ static void exasock_tcp_send_ack(struct exasock_tcp *tcp, bool dup)
         struct exa_socket_state *state = tcp->user_page;
         uint32_t seq = state->p.tcp.send_seq;
         if (state->p.tcp.state == EXA_TCP_TIME_WAIT ||
-            state->p.tcp.state == EXA_TCP_CLOSING)
+            state->p.tcp.state == EXA_TCP_CLOSING ||
+            state->p.tcp.state == EXA_TCP_FIN_WAIT_2)
         {
             seq++;
         }


### PR DESCRIPTION
The ExaSock TCP state machine (in both the user space driver and kernel module) contains an off-by-one error in sequence number tracking in the FIN-WAIT-2 state (i.e. after sending a FIN and receiving its ACK, while awaiting the peer’s FIN).

Specifically, the tracked sequence number (seq) does not account for the FIN consuming one byte in the TCP sequence space (per RFC 793), leaving it one byte behind the correct value.

This can cause undesired behaviour when interacting with other TCP stacks e.g. continuous TCP re-ACKs between endpoints.

It's worth noting that this logic is correct for `TIME-WAIT` and `CLOSING` states.

I've used a ExaNIC testing setup to validate this behaviour of this patch using the packetdrill tool.

```
/run_tests.sh opsynxsr5043 xnc0 xnc8 --preload /usr/lib64/exasock/libexasock_preload.so
Host: opsynxsr5043
Client: xnc0 (192.168.1.10)
Server: xnc8 (192.168.1.18)
Remote IP: 192.168.1.253 (fake)
LD_PRELOAD: /usr/lib64/exasock/[libexasock_preload.so](http://libexasock_preload.so/)
Copying files to opsynxsr5043:/tmp/packetdrill_tests ...
Running setup_wire.sh ...
Configuring wire mode: client=xnc0, server=xnc8
Wire mode setup complete.
PASS tcp_basic_client.pkt
PASS tcp_basic_server.pkt
PASS tcp_blocking_accept.pkt
PASS tcp_blocking_connect.pkt
PASS tcp_close_local_close_then_remote_fin.pkt
PASS tcp_close_on_syn_sent.pkt
PASS tcp_close_remote_fin_then_close.pkt
FAIL tcp_fin_wait_2_seq.pkt
FAIL tcp_shutdown_wr_close.pkt
PASS tcp_validate_established_no_flags.pkt
Results: 8 passed, 2 failed out of 10 tests
Failures:
tcp_fin_wait_2_seq.pkt
tcp_shutdown_wr_close.pkt

# after patching drivers

./run_tests.sh opsynxsr5043 xnc0 xnc8 --preload /usr/lib64/exasock/libexasock_preload.so
Host: opsynxsr5043
Client: xnc0 (192.168.1.10)
Server: xnc8 (192.168.1.18)
Remote IP: 192.168.1.253 (fake)
LD_PRELOAD: /usr/lib64/exasock/[libexasock_preload.so](http://libexasock_preload.so/)
Copying files to opsynxsr5043:/tmp/packetdrill_tests ...
Running setup_wire.sh ...
Configuring wire mode: client=xnc0, server=xnc8
Wire mode setup complete.
PASS tcp_basic_client.pkt
PASS tcp_basic_server.pkt
PASS tcp_blocking_accept.pkt
PASS tcp_blocking_connect.pkt
PASS tcp_close_local_close_then_remote_fin.pkt
PASS tcp_close_on_syn_sent.pkt
PASS tcp_close_remote_fin_then_close.pkt
PASS tcp_fin_wait_2_seq.pkt
PASS tcp_shutdown_wr_close.pkt
PASS tcp_validate_established_no_flags.pkt
```